### PR TITLE
Fix script to query only consuming segments

### DIFF
--- a/scripts/reset_consuming_state.py
+++ b/scripts/reset_consuming_state.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import requests
 
-
 headers = {
     'accept': 'application/json'
 }
@@ -17,37 +16,85 @@ def make_post_request(url, headers=None, data=None, json=None):
     response.raise_for_status()  # Raise an exception for HTTP errors
     return response
 
-def filter_response_by_field(url, segment_names, field_path, value, table):
-    consumers = dict()
-    getUrl = url + "zk/get?path=%2Fpinot%2FPROPERTYSTORE%2FSEGMENTS%2F" + table
-    for s in segment_names:
-        data = make_get_request(getUrl + "/" + s)
-        if data['simpleFields']['segment.realtime.status'] == 'IN_PROGRESS':
-            consumers[s] = data
-    return consumers
+class PinotControllerClient(object):
+    def __init__(self, port, table) -> None:
+        self.pinot_controller_port = port
+        self.table = table
+        self.base_url = "http://localhost:" + self.pinot_controller_port  + "/"
+        self.consuming_segments_url = None
+        self.segment_metadata_url = None
+        self.segment_metadata_put_url = None
+        self._create_urls()
 
+    def _create_urls(self):
+        self.consuming_segments_url = "{0}tables/{1}/consumingSegmentsInfo".format(self.base_url, self.table)
+        base_path = "path=%2Fpinot%2FPROPERTYSTORE%2FSEGMENTS%2F"
+        self.segment_metadata_url = "{0}zk/get?{1}{2}".format(self.base_url, base_path, self.table)
+        self.segment_metadata_put_url = "{0}zk/put?{1}{2}".format(self.base_url, base_path, self.table)
+
+    def get_consuming_segments_list(self):
+        response = make_get_request(self.consuming_segments_url, headers=headers)
+        # for k in response['_segmentToConsumingInfoMap']:
+        #     segments.append(k)
+        #     # print(k, response['_segmentToConsumingInfoMap'][k])
+        # print(len(segments))
+        # return segments
+        return list(response['_segmentToConsumingInfoMap'].keys())
+
+    def get_segments_metadata(self, consuming_segments):
+        segment_to_metadata_dict = dict()
+        for segment in consuming_segments:
+            metadata = make_get_request(self.consuming_segments_url + "/" + segment)
+            if metadata['simpleFields']['segment.realtime.status'] == 'IN_PROGRESS':
+                segment_to_metadata_dict[segment] = metadata
+            else:
+                print("Warning. Segment={0} is not InProgress".format(segment))
+                print(metadata['simpleFields']['segment.realtime.status'])
+                # Since it is best effort, not erroring on it
+        return segment_to_metadata_dict
+
+    def reset_segment_state(self, segment_to_metadata_dict):
+        for segment, metadata in segment_to_metadata_dict.items():
+            print("Consuming segment name={0}, startOffset={1}".format(
+                str(segment)), 
+                metadata['simpleFields']['segment.realtime.startOffset'])
+            metadata['simpleFields']['segment.realtime.startOffset'] = "0"
+            metadata = json.dumps(metadata, indent=4)
+            if not args.dry_run:
+                print("Setting segment value to " + metadata)
+                response = make_post_request(
+                    self.segment_metadata_put_url + "/" + segment, 
+                    data=metadata, 
+                    headers=headers)
+                response.raise_for_status()  # Raise an exception for HTTP errors
+                print(response)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Client to reset consuming state')
+    parser.add_argument('--dry-run', type=bool, default=False, required=False)
+    parser.add_argument('--pinot-controller-port', 
+                        type=str, 
+                        default=9000, 
+                        required=False,
+                        help="Port forward for PinotController")
+    parser.add_argument('--table', 
+                        type=str,
+                        default="kf_logs_REALTIME", 
+                        required=True,
+                        choices=['kf_logs_REALTIME', 
+                                 'kf_metrics_REALTIME', 
+                                 'kf_traces_REALTIME'],
+                        help="Specify Pinot Tables")
+    return parser.parse_args()
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Log ingest client')
-    parser.add_argument('--dry-run', type=bool, default=False, required=False)
-    parser.add_argument('--pinot-controller-port', type=str, default=9000, required=True)
-    parser.add_argument('--table', type=str, default="kf_logs", required=True,
-                        help="One of kf_logs_REALTIME or kf_metrics_REALTIME or kf_traces_REALTIME")
+    args = parse_args()
 
-    args = parser.parse_args()
+    pc = PinotControllerClient(
+        port=args.pinot_controller_port, 
+        table=args.table)
 
-    url = "http://localhost:" + args.pinot_controller_port  + "/"
-    listUrl = url + "zk/ls?path=%2Fpinot%2FPROPERTYSTORE%2FSEGMENTS%2F" + args.table
-    response = make_get_request(listUrl, headers=headers)
-    consuming_segments = filter_response_by_field(url, response, 'segment.realtime.status', 'CONSUMING', args.table)
-    putUrl = url + "zk/put?path=%2Fpinot%2FPROPERTYSTORE%2FSEGMENTS%2F" + args.table
-    print("found " + str(len(consuming_segments.items())) + " consuming segments")
-    for c, v in consuming_segments.items():
-        print("Consuming segment name " + str(c) + " startOffset " + v['simpleFields']['segment.realtime.startOffset'])
-        v['simpleFields']['segment.realtime.startOffset'] = "0"
-        v = json.dumps(v, indent=4)
-        if not args.dry_run:
-            print("Setting segment value to " + v)
-            response = make_post_request(putUrl + "/" + c, data=v, headers=headers)
-            response.raise_for_status()  # Raise an exception for HTTP errors
-            print(response)
+    consuming_segments = pc.get_consuming_segments_list()
+    segment_to_metadata_dict = pc.get_segments_metadata(consuming_segments)
+    pc.reset_segment_state(segment_to_metadata_dict)


### PR DESCRIPTION
**Problem?**
The script was written in such a way that it would query for all the segments. While only the last segment per partition is needed.

**Solution?**
Update the script to use only consuming segments and then update the state.