### PR TITLE
modify and fix the backup and restore configdb scripts

### DIFF
--- a/scripts/backupconfigdb.sh
+++ b/scripts/backupconfigdb.sh
@@ -1,10 +1,15 @@
+#!/bin/bash
 set -x
 
 S3_PATH=$1
 
 if [ -z "$S3_PATH" ] ; then
-echo "Usage: ./backupconfigdb.sh s3path"
-exit 1
+  echo "Usage: ./backupconfigdb.sh s3path"
+  exit 1
 fi
 
-kubectl exec -it kfuse-configdb-0 -- bash -c "PGPASSWORD=password pg_dumpall -U postgres"  | gzip | aws s3 cp - "$S3_PATH"
+DBS=("alertsdb" "beffedb" "hydrationdb" "logsconfigdb" "rbacdb" "apmconfigdb")
+
+for DB in "${DBS[@]}"; do
+  kubectl exec -it kfuse-configdb-0 -- bash -c "PGPASSWORD=password pg_dump -U postgres -d $DB" | gzip | aws s3 cp - "$S3_PATH/$DB.sql.gz"
+done

--- a/scripts/restoreconfigdb.sh
+++ b/scripts/restoreconfigdb.sh
@@ -46,7 +46,10 @@ SERVICES=("user-mgmt-service" "kfuse-grafana" "trace-query-service")
 
 echo "Storing original replica counts in ReplicaSet annotations..."
 for service in "${SERVICES[@]}"; do
-  get_or_set_replicas $service
+  if ! get_or_set_replicas $service; then
+        echo "Failed to process replica count for $service. Exiting." >&2
+    exit 1
+  fi
   scale_deployment $service 0
 done
 

--- a/scripts/restoreconfigdb.sh
+++ b/scripts/restoreconfigdb.sh
@@ -1,10 +1,38 @@
+#!/bin/bash
 set -x
 
 S3_PATH=$1
 
 if [ -z "$S3_PATH" ] ; then
-echo "Usage: ./restoreconfigdb.sh s3path"
-exit 1
+  echo "Usage: ./restoreconfigdb.sh s3path"
+  exit 1
 fi
 
-aws s3 cp "$S3_PATH" - | gzip -d |  kubectl exec -it kfuse-configdb-0 --  bash -c "PGPASSWORD=password psql -q -U postgres"
+DBS=("alertsdb" "beffedb" "hydrationdb" "logsconfigdb" "rbacdb" "apmconfigdb")
+
+echo "Scaling down services..."
+kubectl scale deployment user-mgmt-service --replicas=0 >/dev/null 2>&1
+kubectl scale deployment kfuse-grafana --replicas=0 >/dev/null 2>&1
+kubectl scale deployment trace-query-service --replicas=0 >/dev/null 2>&1
+
+sleep 30  # Wait for services to scale down
+
+echo "Dropping and recreating databases..."
+for DB in "${DBS[@]}"; do
+  kubectl exec -i kfuse-configdb-0 -- bash -c "PGPASSWORD=password psql -U postgres -q -c \"\pset format unaligned; DROP DATABASE IF EXISTS $DB;\"" >/dev/null 2>&1
+  kubectl exec -i kfuse-configdb-0 -- bash -c "PGPASSWORD=password psql -U postgres -q -c \"\pset format unaligned; CREATE DATABASE $DB;\"" >/dev/null 2>&1
+done
+
+echo "Restoring databases..."
+for DB in "${DBS[@]}"; do
+  echo "Restoring $DB..."
+  aws s3 cp "$S3_PATH/$DB.sql.gz" - | gzip -d | \
+    kubectl exec -i kfuse-configdb-0 -- bash -c "PGPASSWORD=password psql -U postgres -d $DB -q" 2>&1 | grep -v "already exists" || true
+done
+
+echo "Scaling up services..."
+kubectl scale deployment user-mgmt-service --replicas=1 >/dev/null 2>&1
+kubectl scale deployment kfuse-grafana --replicas=1 >/dev/null 2>&1
+kubectl scale deployment trace-query-service --replicas=1 >/dev/null 2>&1
+
+echo "Restore process completed!"

--- a/scripts/restoreconfigdb.sh
+++ b/scripts/restoreconfigdb.sh
@@ -10,11 +10,29 @@ fi
 
 DBS=("alertsdb" "beffedb" "hydrationdb" "logsconfigdb" "rbacdb" "apmconfigdb")
 
-# Store original replica counts
-echo "Storing original replica counts..."
-UMS_REPLICAS=$(kubectl get deployment user-mgmt-service -o=jsonpath='{.spec.replicas}')
-GRAFANA_REPLICAS=$(kubectl get deployment kfuse-grafana -o=jsonpath='{.spec.replicas}')
-TQS_REPLICAS=$(kubectl get deployment trace-query-service -o=jsonpath='{.spec.replicas}')
+# Function to get or set original replicas using ReplicaSet annotations
+get_or_set_replicas() {
+    local deployment=$1
+    
+    # Get the newest ReplicaSet directly from deployment
+    RS_NAME=$(kubectl describe deployment $deployment | grep "NewReplicaSet:" | awk '{print $2}')
+    
+    # Try to get existing annotation first
+    ORIGINAL_REPLICAS=$(kubectl get rs $RS_NAME -o=jsonpath='{.metadata.annotations.original-replicas}' 2>/dev/null)
+    
+    if [ -z "$ORIGINAL_REPLICAS" ]; then
+        # If annotation doesn't exist, get current replicas and set annotation
+        ORIGINAL_REPLICAS=$(kubectl get deployment $deployment -o=jsonpath='{.spec.replicas}')
+        kubectl annotate rs $RS_NAME original-replicas=$ORIGINAL_REPLICAS --overwrite
+    fi
+    
+    echo $ORIGINAL_REPLICAS
+}
+
+echo "Storing original replica counts in ReplicaSet annotations..."
+UMS_REPLICAS=$(get_or_set_replicas user-mgmt-service)
+GRAFANA_REPLICAS=$(get_or_set_replicas kfuse-grafana)
+TQS_REPLICAS=$(get_or_set_replicas trace-query-service)
 
 echo "Scaling down services..."
 kubectl scale deployment user-mgmt-service --replicas=0 >/dev/null 2>&1
@@ -36,7 +54,15 @@ for DB in "${DBS[@]}"; do
     kubectl exec -i kfuse-configdb-0 -- bash -c "PGPASSWORD=password psql -U postgres -d $DB -q" 2>&1 | grep -v "already exists" || true
 done
 
-echo "Scaling up services to original replica counts..."
+echo "Scaling up services to original replica counts from ReplicaSet annotations..."
+UMS_RS=$(kubectl describe deployment user-mgmt-service | grep "NewReplicaSet:" | awk '{print $2}')
+GRAFANA_RS=$(kubectl describe deployment kfuse-grafana | grep "NewReplicaSet:" | awk '{print $2}')
+TQS_RS=$(kubectl describe deployment trace-query-service | grep "NewReplicaSet:" | awk '{print $2}')
+
+UMS_REPLICAS=$(kubectl get rs $UMS_RS -o=jsonpath='{.metadata.annotations.original-replicas}')
+GRAFANA_REPLICAS=$(kubectl get rs $GRAFANA_RS -o=jsonpath='{.metadata.annotations.original-replicas}')
+TQS_REPLICAS=$(kubectl get rs $TQS_RS -o=jsonpath='{.metadata.annotations.original-replicas}')
+
 kubectl scale deployment user-mgmt-service --replicas=$UMS_REPLICAS >/dev/null 2>&1
 kubectl scale deployment kfuse-grafana --replicas=$GRAFANA_REPLICAS >/dev/null 2>&1
 kubectl scale deployment trace-query-service --replicas=$TQS_REPLICAS >/dev/null 2>&1

--- a/scripts/restoreconfigdb.sh
+++ b/scripts/restoreconfigdb.sh
@@ -10,6 +10,12 @@ fi
 
 DBS=("alertsdb" "beffedb" "hydrationdb" "logsconfigdb" "rbacdb" "apmconfigdb")
 
+# Store original replica counts
+echo "Storing original replica counts..."
+UMS_REPLICAS=$(kubectl get deployment user-mgmt-service -o=jsonpath='{.spec.replicas}')
+GRAFANA_REPLICAS=$(kubectl get deployment kfuse-grafana -o=jsonpath='{.spec.replicas}')
+TQS_REPLICAS=$(kubectl get deployment trace-query-service -o=jsonpath='{.spec.replicas}')
+
 echo "Scaling down services..."
 kubectl scale deployment user-mgmt-service --replicas=0 >/dev/null 2>&1
 kubectl scale deployment kfuse-grafana --replicas=0 >/dev/null 2>&1
@@ -30,9 +36,9 @@ for DB in "${DBS[@]}"; do
     kubectl exec -i kfuse-configdb-0 -- bash -c "PGPASSWORD=password psql -U postgres -d $DB -q" 2>&1 | grep -v "already exists" || true
 done
 
-echo "Scaling up services..."
-kubectl scale deployment user-mgmt-service --replicas=1 >/dev/null 2>&1
-kubectl scale deployment kfuse-grafana --replicas=1 >/dev/null 2>&1
-kubectl scale deployment trace-query-service --replicas=1 >/dev/null 2>&1
+echo "Scaling up services to original replica counts..."
+kubectl scale deployment user-mgmt-service --replicas=$UMS_REPLICAS >/dev/null 2>&1
+kubectl scale deployment kfuse-grafana --replicas=$GRAFANA_REPLICAS >/dev/null 2>&1
+kubectl scale deployment trace-query-service --replicas=$TQS_REPLICAS >/dev/null 2>&1
 
 echo "Restore process completed!"


### PR DESCRIPTION
I tested the original scripts for backup and restoring the configdb; they were not working as expected. 
For example, when I backedup and restored it on ashish namespace, I didn't get all the data restored back in all the rbac tables such as groups, rbac_policies.

I think as we were using pg_dumpall, which dumps all databases but does not include per-database schemas, or certain other objects correctly when restoring.

Fixes Implemented:
✅ Each database is dumped separately – ensuring full data preservation.
✅ Restores into the correct databases
✅ Ensures schemas and permissions are correctly preserved.

Also added following to the restore script - 
1. Scaling down user-mgmt-service, kfuse-grafana and trace-query-service
2. Dropping and recreating alertsdb, beffedb, hydrationdb, logsconfigdb, rbacdb, apmconfigdb databases
3. Doing the actual restore
4. Scaling up the services again

as mentioned by @ashishkf 

This is the sample AWS S3 bucket I used for testing - 
https://us-west-2.console.aws.amazon.com/s3/buckets/test-backup-script-surya?region=us-west-2&bucketType=general&prefix=/&showversions=false

Commands used - 

For backup-
```
 ./backupconfigdb.sh s3://test-backup-script-surya/ 
```
For restore-
```
./restoreconfigdb.sh s3://test-backup-script-surya/    
```