### PR TITLE
[Bug Fix] for Single Alert download from a folder with multiple rule_groups

### DIFF
--- a/scripts/assets/common/grafana_client.py
+++ b/scripts/assets/common/grafana_client.py
@@ -247,20 +247,23 @@ class GrafanaClient:
             rules = None
             log.debug("KeyError: Skipping folder_name={} as it does not exist in existing_alerts", folder_name)
             return None, False
-        for r in rules:
-            rule_title = r["grafana_alert"]["title"]
-            if all_alerts or rule_title == alert_name:
-                log.debug("Keeping alert: {0}".format(rule_title))
-                new_rules.append(r)
-            else:
-                log.debug("Skipping alert: {0}".format(rule_title))
+        rule_group_index = 0
+        for index, group in enumerate(existing_alerts[0][folder_name]):
+            for r in group["rules"]:
+                rule_title = r["grafana_alert"]["title"]
+                if all_alerts or rule_title == alert_name:
+                    log.debug("Keeping alert: {0}".format(rule_title))
+                    new_rules.append(r)
+                    rule_group_index = index
+                else:
+                    log.debug("Skipping alert: {0}".format(rule_title))
 
         if len(new_rules) == 0:
             log.warning("Alert not found: {0}".format(alert_name))
-            return None, False
+            return None, False            
 
-        existing_alerts[0][folder_name][0]["rules"] = new_rules
-        return existing_alerts[0][folder_name][0], True
+        existing_alerts[0][folder_name][rule_group_index]["rules"] = new_rules
+        return existing_alerts[0][folder_name][rule_group_index], True
     
     def download_alerts_folder(self, folder_name):
         log.debug("Download all alerts from folder={0}".format(

--- a/scripts/assets/common/grafana_client.py
+++ b/scripts/assets/common/grafana_client.py
@@ -240,23 +240,22 @@ class GrafanaClient:
             return None, False
 
         new_rules = []
-        try:
-            rules = existing_alerts[0][folder_name][0]["rules"]
+
+        rule_group_index = 0
+        try: 
+            for index, group in enumerate(existing_alerts[0][folder_name]):
+                for r in group["rules"]:
+                    rule_title = r["grafana_alert"]["title"]
+                    if all_alerts or rule_title == alert_name:
+                        log.debug("Keeping alert: {0}".format(rule_title))
+                        new_rules.append(r)
+                        rule_group_index = index
+                    else:
+                        log.debug("Skipping alert: {0}".format(rule_title))
         except KeyError:
             # Skip this if the key does not exist
-            rules = None
             log.debug("KeyError: Skipping folder_name={} as it does not exist in existing_alerts", folder_name)
             return None, False
-        rule_group_index = 0
-        for index, group in enumerate(existing_alerts[0][folder_name]):
-            for r in group["rules"]:
-                rule_title = r["grafana_alert"]["title"]
-                if all_alerts or rule_title == alert_name:
-                    log.debug("Keeping alert: {0}".format(rule_title))
-                    new_rules.append(r)
-                    rule_group_index = index
-                else:
-                    log.debug("Skipping alert: {0}".format(rule_title))
 
         if len(new_rules) == 0:
             log.warning("Alert not found: {0}".format(alert_name))


### PR DESCRIPTION
Before:
Downloading a single alert from a Folder which has multiple different `rule_groups` can run into issues, because only the First rule group was being searched for the Single Alert.

After:
Downloading a single alert from a Folder which has multiple different `rule_groups`, searched within all rule groups and download's alert from the correct group.

Rest of testing done:

- [x]  All alerts from a folder with multiple rule groups are downloadable
- [x] All alerts from all folders are downloadabe

Fix for issue - https://github.com/kloudfuse/customer-gehealthcare/issues/295